### PR TITLE
Support for cycle in package tree.

### DIFF
--- a/src/copy-production-deps.ts
+++ b/src/copy-production-deps.ts
@@ -149,7 +149,11 @@ function lookForDependenciesInWorkspace(pkg: SourcePackage, dependencies: Depend
                         pkg,
                         context
                     );
-                    subPackages.push(newDep);
+
+                    // Only process this package, if we're the first user.
+                    if (newDep.users.length === 1) {
+                        subPackages.push(newDep);
+                    }
                     pkg.deps.push(newDep);
                     break;
                 }


### PR DESCRIPTION
`lookForDependenciesInWorkspace` skips processing packages that were
already processed.

Fixes #4